### PR TITLE
Update README "./yii" to "php yii"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ You need a server (vps will be ok) with linux, root access and configured LEMP, 
 - run `chmod 0777 web/assets`
 - run `chmod 0777 web/uploads`
 - copy `config/db.dist` => `config/db.php` and enter the access data to the created database
-- run `./yii migrate` (tables in the database should be created)
-- run `./yii admin/dictionaries` 
+- run `php yii migrate` (tables in the database should be created)
+- run `php yii admin/dictionaries` 
 
 ## Configure google sign-in
 - go to: https://console.developers.google.com and create a new project
@@ -72,11 +72,11 @@ You need a server (vps will be ok) with linux, root access and configured LEMP, 
     * `numprocs` => `2` is enough (I recommend twice less than the number of proxy and a number equal to the number of processor cores/threads)
     * I suggest `stdout_logfile` to be set to the project directory, ie `PROJECT_FULL_PATH/runtime/logs/supervisor.log`
 - run `supervisord`
-- add [cron hourly](https://crontab.guru/every-hour) for `/PROJECT_FULL_PATH/yii stats/update-accounts` and `/PROJECT_FULL_PATH/yii stats/update-tags`
+- add [cron hourly](https://crontab.guru/every-hour) for `php /PROJECT_FULL_PATH/yii stats/update-accounts` and `php /PROJECT_FULL_PATH/yii stats/update-tags`
 
 ## Adding and activation of the system user
 - try to log in, if everything goes well, you'll see an "inactive account message"
-- run the command `./yii user/activate 'YOUR_GOOGLE_EMAIL'`
+- run the command `php yii user/activate 'YOUR_GOOGLE_EMAIL'`
 - log in again
 
 ## Next steps


### PR DESCRIPTION
Changing all the ./yii to php yii
This makes it easier for the people to setup the website as if people try to run yii with ./yii then it's highly likely that they get permission denied error or something similar but if they just do "php yii command/here" then it runs yii with php and it doesn't cause any errors for people.

Comparison below:

![screenshot_20190208_225913](https://user-images.githubusercontent.com/5682352/52510757-348abc00-2bf5-11e9-9f6d-ba62c1a88083.png)
