### PR TITLE
Do not use fixture module on production

### DIFF
--- a/config/console.php
+++ b/config/console.php
@@ -60,13 +60,6 @@ $config = [
                 'yii\queue\db\migrations',
             ],
         ],
-        'fixture' => [ // Fixture generation command line.
-            'class' => \yii\faker\FixtureController::class,
-            'templatePath' => 'tests/fixtures/templates',
-            'fixtureDataPath' => 'tests/fixtures/data',
-            'namespace' => 'app\tests\fixtures',
-            'count' => 10,
-        ],
     ],
 ];
 
@@ -75,6 +68,13 @@ if (YII_ENV_DEV) {
     $config['bootstrap'][] = 'gii';
     $config['modules']['gii'] = [
         'class' => 'yii\gii\Module',
+    ];
+    $config['modules']['fixture'] = [ // Fixture generation command line.
+      'class' => \yii\faker\FixtureController::class,
+      'templatePath' => 'tests/fixtures/templates',
+      'fixtureDataPath' => 'tests/fixtures/data',
+      'namespace' => 'app\tests\fixtures',
+      'count' => 10,
     ];
 }
 


### PR DESCRIPTION
Fixture module needs faker, and faker is in composer-dev
dependencies, so if you are installing on a production with
`composer install --no-dev`, you won't be able to run `yii`
in console without this config change.