### PR TITLE
Fixed Incorrect string value for unicode languages

### DIFF
--- a/migrations/m180522_154836_add_accounts_default_tags_column_to_account_table.php
+++ b/migrations/m180522_154836_add_accounts_default_tags_column_to_account_table.php
@@ -12,7 +12,7 @@ class m180522_154836_add_accounts_default_tags_column_to_account_table extends M
      */
     public function safeUp()
     {
-        $this->addColumn('account', 'accounts_default_tags', $this->string());
+        $this->addColumn('account', 'accounts_default_tags', $this->string()->append('CHARACTER SET utf8 COLLATE utf8_unicode_ci'));
     }
 
     /**


### PR DESCRIPTION
The fix adds support for unicode languages in accounts_default_tags