### PR TITLE
Invalidate proxy on error and log last unknown error

### DIFF
--- a/components/http/ProxyManager.php
+++ b/components/http/ProxyManager.php
@@ -52,6 +52,11 @@ class ProxyManager extends Component
         Proxy::updateAll(['reservation_uid' => null], 'reservation_uid=:reservation_uid', [':reservation_uid' => $proxy->reservation_uid]);
     }
 
+    public function invalidate(Proxy $proxy)
+    {
+        Proxy::updateAll(['active' => false], 'id=:id', [':id' => $proxy->id]);
+    }
+
     protected function generateUid()
     {
         return sprintf('%s_%s', Yii::$app->security->generateRandomString(64), time());

--- a/components/updaters/AccountUpdater.php
+++ b/components/updaters/AccountUpdater.php
@@ -90,6 +90,15 @@ class AccountUpdater extends Component
         return $this;
     }
 
+    public function setIsInvalidUnknown(string $message = null)
+    {
+        $this->account->is_valid = 0;
+        $this->account->invalidation_count = (int)$this->account->invalidation_count + 1;
+        $this->account->last_invalidation_unknown = $message;
+
+        return $this;
+    }
+
     /**
      * If true, then will be automatically calculate from invalidation_count
      *

--- a/dictionaries/AccountInvalidationType.php
+++ b/dictionaries/AccountInvalidationType.php
@@ -13,6 +13,8 @@ class AccountInvalidationType extends Dictionary
     const IS_PRIVATE = 1;
     const NOT_FOUND = 2;
     const RESTRICTED_PROFILE = 3;
+    const PROXY_TIMEOUT = 4;
+    const PROXY_ERROR = 5;
 
     public static function labels(): array
     {
@@ -20,6 +22,8 @@ class AccountInvalidationType extends Dictionary
             self::IS_PRIVATE => 'Is private',
             self::NOT_FOUND => 'Not found',
             self::RESTRICTED_PROFILE => 'Restricted profile',
+            self::PROXY_TIMEOUT => 'Proxy Timeout',
+            self::PROXY_ERROR => 'Proxy Error',
         ];
     }
 }

--- a/migrations/m190917_110419_add_last_invalidation_unknown_column_to_account_table.php
+++ b/migrations/m190917_110419_add_last_invalidation_unknown_column_to_account_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles adding columns to table `{{%account}}`.
+ */
+class m190917_110419_add_last_invalidation_unknown_column_to_account_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function up()
+    {
+        $this->addColumn('account', 'last_invalidation_unknown', $this->text());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function down()
+    {
+        $this->dropColumn('account', 'notes');
+    }
+}

--- a/models/Account.php
+++ b/models/Account.php
@@ -24,6 +24,7 @@ use yii\helpers\ArrayHelper;
  * @property bool $monitoring
  * @property int $proxy_id
  * @property bool $is_valid [tinyint(1)]
+ * @property string $last_invalidation_unknown
  * @property int $invalidation_type_id [int(11)]
  * @property int $invalidation_count [int(11)]
  * @property string $update_stats_after [datetime]

--- a/modules/admin/widgets/InvalidAccountAlert.php
+++ b/modules/admin/widgets/InvalidAccountAlert.php
@@ -37,9 +37,9 @@ class InvalidAccountAlert extends Widget
     protected function lines()
     {
         $formatter = Yii::$app->formatter;
-
+        $reason = $this->model->last_invalidation_unknown ? $this->model->last_invalidation_unknown : "Unknown Reason";
         return [
-            sprintf('type: %s', ArrayHelper::getValue(AccountInvalidationType::labels(), $this->model->invalidation_type_id, 'Unknown reason')),
+            sprintf('type: %s', ArrayHelper::getValue(AccountInvalidationType::labels(), $this->model->invalidation_type_id, $reason)),
             sprintf('attempts: %s', $formatter->asInteger($this->model->invalidation_count)),
             sprintf('next try: %s', $formatter->asDatetime($this->model->update_stats_after)),
         ];


### PR DESCRIPTION
Changes:

+ Added last_invalidation_unknown field to account for the latest unknown error.
+ Invalidate proxy on a related error occurrence.